### PR TITLE
OpenCV Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@ Lablet is developed using Intellij IDEA / Android Studio. If you want to build L
 
 Dependencies
 ---
-Lablet depends on OpenCV for Android to provide object tracking functionality. Assuming you have used git to clone Lablet:
-
-1. Download and unzip [OpenCV for Android 2.4.11](http://sourceforge.net/projects/opencvlibrary/files/opencv-android/2.4.11/OpenCV-2.4.11-android-sdk.zip/download).
-2. Copy the directory OpenCV-android-sdk-2.4.11/sdk/native/libs into Lablet/app/src/main
-3. Rename the libs folder (that you just copied) to jniLibs
+Lablet depends on OpenCV for Android to provide object tracking functionality. Lablet will ask the user to install OpenCV Manager the first time Lablet executes.
 
 Links
 ----

--- a/app/src/main/java/nz/ac/auckland/lablet/ScriptHomeActivity.java
+++ b/app/src/main/java/nz/ac/auckland/lablet/ScriptHomeActivity.java
@@ -15,8 +15,17 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.*;
 import android.widget.*;
+
+import org.opencv.android.BaseLoaderCallback;
+import org.opencv.android.LoaderCallbackInterface;
+import org.opencv.android.OpenCVLoader;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.Scalar;
+
 import nz.ac.auckland.lablet.misc.NaturalOrderComparator;
 import nz.ac.auckland.lablet.misc.StorageLib;
 import nz.ac.auckland.lablet.script.LuaScriptLoader;
@@ -160,6 +169,7 @@ class ScriptDirs {
  */
 public class ScriptHomeActivity extends Activity {
     static final public String REMOTE_TYPE = "remote";
+    static final private String TAG = "OpenCV";
 
     private List<ScriptMetaData> scriptList = null;
     private ArrayAdapter<ScriptMetaData> scriptListAdaptor = null;
@@ -173,6 +183,35 @@ public class ScriptHomeActivity extends Activity {
     private CheckBox selectAllCheckBox = null;
 
     final static private int START_SCRIPT = 1;
+
+    private BaseLoaderCallback mLoaderCallback = new BaseLoaderCallback(this) {
+        @Override
+        public void onManagerConnected(int status) {
+            switch(status) {
+                case LoaderCallbackInterface.SUCCESS:
+                    Log.i(TAG,"OpenCV Manager Connected");
+                    //from now onwards, you can use OpenCV API
+                    Mat m = new Mat(5, 10, CvType.CV_8UC1, new Scalar(0));
+                    break;
+                case LoaderCallbackInterface.INIT_FAILED:
+                    Log.i(TAG,"Init Failed");
+                    break;
+                case LoaderCallbackInterface.INSTALL_CANCELED:
+                    Log.i(TAG,"Install Cancelled");
+                    break;
+                case LoaderCallbackInterface.INCOMPATIBLE_MANAGER_VERSION:
+                    Log.i(TAG,"Incompatible Version");
+                    break;
+                case LoaderCallbackInterface.MARKET_ERROR:
+                    Log.i(TAG,"Market Error");
+                    break;
+                default:
+                    Log.i(TAG,"OpenCV Manager Install");
+                    super.onManagerConnected(status);
+                    break;
+            }
+        }
+    };
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -392,6 +431,9 @@ public class ScriptHomeActivity extends Activity {
     @Override
     public void onResume() {
         super.onResume();
+
+        //initialize OpenCV manager
+        OpenCVLoader.initAsync(OpenCVLoader.OPENCV_VERSION_2_4_8, this, mLoaderCallback);
 
         selectAllCheckBox.setChecked(false);
         invalidateOptionsMenu();


### PR DESCRIPTION
This pull eases the process of installing OpenCV, which is required for Lablet.

Instead of requiring the developer to download OpenCV as a separate package and build it into Lablet, this change simply asks the user to download the OpenCV library in app form when Lablet is executed the first time. This should make the Lablet app size significantly smaller and also ensure that OpenCV is kept up-to-date.